### PR TITLE
fix: use graphql-ws for subscriptions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -45,19 +45,17 @@
     "@graphql-tools/utils": "^8.6.1",
     "ajv": "^8.10.0",
     "apollo-server-core": "^3.6.3",
-    "apollo-server-fastify": "^3.6.3",
+    "apollo-server-express": "^3.6.3",
     "delay": "^5.0.0",
     "env-var": "^7.1.1",
-    "fastify": "^3.27.1",
-    "fastify-plugin": "^3.0.1",
-    "fastify-websocket": "^4.0.0",
+    "express": "^4.17.3",
     "graphql": "^16.3.0",
-    "graphql-subscriptions": "2.0.0",
+    "graphql-subscriptions": "^2.0.0",
+    "graphql-ws": "^5.6.0",
     "humanize-duration": "^3.27.1",
     "make-promises-safe": "^5.1.0",
     "nanoid": "^3.2.0",
     "pino": "^7.6.5",
-    "subscriptions-transport-ws": "^0.11.0",
     "ws": "^8.4.2"
   }
 }

--- a/backend/src/graphql/modules/game.configuration/resolvers.ts
+++ b/backend/src/graphql/modules/game.configuration/resolvers.ts
@@ -30,9 +30,13 @@ const resolvers: Resolvers = {
   },
   Subscription: {
     gameConfig: {
-      subscribe: async () =>
-        pubsub.asyncIterableIterator(['GAME_STATE_UPDATED']),
-    },
+      resolve: () => gameConfig,
+      subscribe: async () => ({
+        [Symbol.asyncIterator]() {
+          return pubsub.asyncIterator('GAME_STATE_UPDATED');
+        }
+      })
+    }
   },
 };
 

--- a/backend/src/plugins/health.ts
+++ b/backend/src/plugins/health.ts
@@ -1,34 +1,31 @@
-import { FastifyPluginCallback } from 'fastify';
-import fp from 'fastify-plugin';
+import type { WebSocketServer } from 'ws';
+import type { Request, Response } from 'express';
+
 import { uptime } from 'process';
 import humanize from 'humanize-duration';
 import log from '../log';
+
+// import { createRequire } from 'module'
+// const require = createRequire(import.meta.url);
 
 export interface HealthPluginOptions {
   version: string;
 }
 
-const healthPlugin: FastifyPluginCallback<HealthPluginOptions> = (
-  server,
-  options,
-  done
-) => {
-  log.info('mounting health plugin');
-  server.route({
-    method: 'GET',
-    url: '/health',
-    handler: async () => {
-      return {
-        connectedClients: server.websocketServer.clients.size,
-        status: 'ok',
-        uptime: humanize(uptime() * 1000),
-        serverTs: new Date().toJSON(),
-        version: options.version,
-      };
-    },
-  });
-
-  done();
-};
-
-export default fp(healthPlugin);
+export function healthCheck(wsServer: WebSocketServer) {
+  log.info('installing health middleware');
+  return async (_req: Request, res: Response) => {
+    // `wsServer` is a reference to the WebSocketServer instance
+    const connectedClients = wsServer.clients.size;
+    // if ts-node doesn't speak `require`, we'll bump `module` and use `createRequire`
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { version } = require('../../package.json');
+    res.json({
+      connectedClients,
+      status: 'ok',
+      uptime: humanize(uptime() * 1000),
+      serverTs: new Date().toJSON(),
+      version,
+    })
+  };
+}

--- a/backend/src/views/graphiql/index.html
+++ b/backend/src/views/graphiql/index.html
@@ -1,0 +1,121 @@
+<!--
+ *  Copyright (c) 2021 GraphQL Contributors
+ *  All rights reserved.
+ *
+ *  This code is licensed under the MIT license.
+ *  Use it however you wish.
+-->
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+
+    <!--
+      This GraphiQL example depends on Promise and AsyncIterator, which are available in
+      modern browsers, but can be "polyfilled" for older browsers.
+      GraphiQL itself depends on React DOM.
+      If you do not want to rely on a CDN, you can host these files locally or
+      include them directly in your favored resource bunder.
+    -->
+    <script
+      crossorigin
+      src="https://unpkg.com/react@16/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"
+    ></script>
+
+    <!--
+      These two files can be found in the npm module, however you may wish to
+      copy them directly into your environment, or perhaps include them in your
+      favored resource bundler.
+     -->
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  </head>
+
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <script
+      src="https://unpkg.com/graphql-ws/umd/graphql-ws.min.js"
+      type="application/javascript"
+    ></script>
+
+    <script>
+      const wsClient = graphqlWs.createClient({
+        url: "ws://0.0.0.0:8080/graphql",
+        lazy: false, // connect as soon as the page opens
+      });
+
+      function subscribe(payload) {
+        let deferred = null;
+        const pending = [];
+        let throwMe = null,
+          done = false;
+        const dispose = wsClient.subscribe(payload, {
+          next: (data) => {
+            pending.push(data);
+            deferred?.resolve(false);
+          },
+          error: (err) => {
+            if (err instanceof Error) {
+              throwMe = err;
+            } else if (err instanceof CloseEvent) {
+              throwMe = new Error(`Socket closed with event ${err.code} ${err.reason || ""}`.trim());
+            } else {
+              // GraphQLError[]
+              throwMe = new Error(err.map(({ message }) => message).join(", "));
+            }
+            deferred?.reject(throwMe);
+          },
+          complete: () => {
+            done = true;
+            deferred?.resolve(true);
+          },
+        });
+        return {
+          [Symbol.asyncIterator]() {
+            return this;
+          },
+          async next() {
+            if (done) return { done: true, value: undefined };
+            if (throwMe) throw throwMe;
+            if (pending.length) return { value: pending.shift() };
+            return (await new Promise(
+              (resolve, reject) => (deferred = { resolve, reject })
+            ))
+              ? { done: true, value: undefined }
+              : { value: pending.shift() };
+          },
+          async return() {
+            dispose();
+            return { done: true, value: undefined };
+          },
+        };
+      }
+
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: subscribe,
+          defaultVariableEditorOpen: true,
+        }),
+        document.getElementById("graphiql")
+      );
+    </script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,14 +1,14 @@
 {
   "main": "index.html",
   "private": true,
-  "name": "apollo-elements-app",
+  "name": "frontend",
   "version": "1.0.0",
   "type": "module",
   "author": "",
   "license": "ISC",
   "description": "Apollo Elements App",
   "scripts": {
-    "start": "run-p start:*",
+    "start": "concurrently 'yarn workspace frontend start:codegen' 'yarn workspace frontend start:serve'",
     "start:codegen": "graphql-codegen --watch",
     "start:serve": "wds --watch --open",
     "lint": "eslint",

--- a/frontend/src/client.schema.graphql
+++ b/frontend/src/client.schema.graphql
@@ -1,31 +1,7 @@
-enum GameState {
-  LOBBY
-  ACTIVE
-  PAUSED
-  STOPPED
-}
-
-type GameConfiguration {
-  uuid: ID!
-  date: String!
-  state: GameState!
-  cluster: String!
+type Location {
+  pathname: String
 }
 
 type Query {
-  gameConfig: GameConfiguration
-}
-
-input ConnectionRequest {
-  username: String
-  gameId: String
-  playerId: String
-}
-
-type Mutation {
-  connect(request: ConnectionRequest): GameConfiguration!
-}
-
-type Subscription {
-  gameConfig: GameConfiguration
+  location: Location
 }

--- a/frontend/src/client.ts
+++ b/frontend/src/client.ts
@@ -1,13 +1,15 @@
-import { ApolloLink, ApolloClient, InMemoryCache, HttpLink, Observable } from '@apollo/client/core';
-import { WebSocketLink } from "@apollo/client/link/ws";
+import {
+  ApolloLink,
+  ApolloClient,
+  InMemoryCache,
+  Observable,
+  FetchResult,
+  Operation,
+} from '@apollo/client/core';
 import { print } from 'graphql';
 import { createClient, ClientOptions, Client } from 'graphql-ws';
 
-const uri = 'http://localhost:8080/graphql';
-
 import { locationVar } from './router';
-
-// export const link = new HttpLink({ uri });
 
 class WebSocketLink extends ApolloLink {
   private client: Client;
@@ -18,7 +20,7 @@ class WebSocketLink extends ApolloLink {
   }
 
   public request(operation: Operation): Observable<FetchResult> {
-    return new Observable((sink) => {
+    return new Observable(sink => {
       return this.client.subscribe<FetchResult>(
         { ...operation, query: print(operation.query) },
         {
@@ -32,7 +34,8 @@ class WebSocketLink extends ApolloLink {
 }
 
 const link = new WebSocketLink({
-  url: 'ws://locahost:8080/graphql',
+  // url: 'ws://localhost:8080/graphql',
+  url: 'ws://0.0.0.0:8080/graphql',
 });
 
 const cache =
@@ -50,3 +53,4 @@ const cache =
 
 export const client =
   new ApolloClient({ cache, link });
+

--- a/frontend/src/components/app/App.query.graphql
+++ b/frontend/src/components/app/App.query.graphql
@@ -1,4 +1,8 @@
 query GameConfigQuery {
+  location @client {
+    pathname
+  }
+
   gameConfig {
     uuid
     date

--- a/frontend/src/components/app/GameConfig.subscription.graphql
+++ b/frontend/src/components/app/GameConfig.subscription.graphql
@@ -1,0 +1,8 @@
+subscription GameConfigUpdated {
+  gameConfig {
+    uuid
+    date
+    state
+    cluster
+  }
+}

--- a/frontend/src/components/app/app.ts
+++ b/frontend/src/components/app/app.ts
@@ -1,25 +1,31 @@
 import { LitElement, html, TemplateResult } from 'lit';
-import { ApolloQueryController, ApolloMutationController } from '@apollo-elements/core';
 import { customElement } from 'lit/decorators.js';
 
+import {
+  ApolloQueryController,
+  ApolloMutationController,
+  ApolloSubscriptionController,
+} from '@apollo-elements/core';
+
 import { GameConfigQuery } from './App.query.graphql.js';
+import { GameConfigUpdated } from './GameConfig.subscription.graphql.js';
 import { ConnectionRequestMutation } from './App.mutation.graphql.js';
 
 import style from './app.css';
 import shared from '../shared.css';
 
 export const getLocalStorage = () => {
-	return {
-    username: localStorage.getItem("username"),
-    gameId: localStorage.getItem("gameId"),
-    playerId: localStorage.getItem("playerId"),
-	};
+  return {
+    username: localStorage.getItem('username'),
+    gameId: localStorage.getItem('gameId'),
+    playerId: localStorage.getItem('playerId'),
+  };
 };
 
 export const updateLocalStorage = (gameId: string, playerId: string, username: string) => {
-	localStorage.setItem("username", username);
-	localStorage.setItem("gameId", gameId);
-	localStorage.setItem("playerId", playerId);
+  localStorage.setItem('username', username);
+  localStorage.setItem('gameId', gameId);
+  localStorage.setItem('playerId', playerId);
 };
 
 @customElement('apollo-app')
@@ -30,27 +36,30 @@ export class ApolloApp extends LitElement {
 
   gameConfigQuery = new ApolloQueryController(this, GameConfigQuery);
   connectionRequestMutation = new ApolloMutationController(this, ConnectionRequestMutation);
-
-  firstUpdated() {
-    this.sendConnectionRequest();
-  }
+  gameConfigSubscription = new ApolloSubscriptionController(this, GameConfigUpdated);
 
   public async sendConnectionRequest() {
     let storedGameConfig = {};
-		// get a previously connected player
-		const previousPlayer = getLocalStorage();
-		if (previousPlayer.gameId && previousPlayer.playerId && previousPlayer.username) {
-			storedGameConfig = previousPlayer;
-		}
-    const { data, error } = await this.connectionRequestMutation.mutate({ variables: storedGameConfig })
-    // store new player and game info
-    if (!error) updateLocalStorage(data);
-    // update the gameconfigQuery
-    this.gameConfigQuery.refetch();
+    // get a previously connected player
+    const previousPlayer = getLocalStorage();
+    if (previousPlayer.gameId && previousPlayer.playerId && previousPlayer.username)
+      storedGameConfig = previousPlayer;
+
+    try {
+      const { data } =
+        await this.connectionRequestMutation.mutate({ variables: storedGameConfig });
+      // store new player and game info
+      updateLocalStorage(data.connect.uuid, 'unknown playerID', 'unknown username');
+      // update the gameconfigQuery
+      this.gameConfigQuery.refetch();
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   render(): TemplateResult {
     return html`
+      <button @click="${this.sendConnectionRequest}">Connect</button>
       <dl>
         <dt>Pathname</dt>
         <dd>${this.gameConfigQuery.data?.location?.pathname ?? '/'}</dd>
@@ -60,6 +69,9 @@ export class ApolloApp extends LitElement {
         <dd>${this.gameConfigQuery.data?.gameConfig?.state}</dd>
         <dd>${this.gameConfigQuery.data?.gameConfig?.date}</dd>
       </dl>
+
+      <h2>Last Config Update</h2>
+      <output>${this.gameConfigSubscription.data?.gameConfig?.uuid}</output>
     `;
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "frontend"
   ],
   "scripts": {
-    "dev": "concurrently \"yarn generate:types --watch\" \"yarn backend:dev\"",
+    "dev": "concurrently \"yarn generate:types --watch\" \"yarn backend:dev\" \"yarn workspace frontend start\"",
     "generate:types": "graphql-codegen"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,12 +9,42 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "2022-game-app@workspace:."
   dependencies:
+    "@apollo-elements/create": ^3.0.3
     "@graphql-codegen/cli": ^2.6.1
     "@graphql-codegen/graphql-modules-preset": ^2.3.3
+    "@graphql-codegen/near-operation-file-preset": ^2.2.2
+    "@graphql-codegen/typed-document-node": ^2.2.1
     "@graphql-codegen/typescript": ^2.4.3
+    "@graphql-codegen/typescript-operations": ^2.2.1
     "@graphql-codegen/typescript-resolvers": ^2.5.0
+    "@open-wc/rollup-plugin-html": ^1.x
+    "@pwrs/eslint-config": ^0.x
+    "@rollup/plugin-commonjs": ^17.x
+    "@rollup/plugin-node-resolve": ^11.x
+    "@types/humanize-duration": ^3.27.1
+    "@types/node": ^16.0.0
+    "@types/ws": ^8.2.2
+    "@typescript-eslint/eslint-plugin": ^5.11.0
+    "@typescript-eslint/parser": ^5.11.0
+    "@web/dev-server": ^0.1.x
+    "@web/dev-server-esbuild": ^0.2.x
+    "@web/dev-server-rollup": ^0.3.x
     concurrently: ^7.0.0
+    dotenv: ^16.0.0
+    eslint: ^8.8.0
     graphql: ^16.3.0
+    graphql-ws: ^5.6.0
+    husky: ~4.3.6
+    nodemon: ^2.0.15
+    npm-run-all: ^4.x
+    pino-pretty: ~4.3.0
+    prettier: ~2.2.1
+    pretty-quick: ~3.1.0
+    rollup: ^2.x
+    rollup-plugin-esbuild: ^2.x
+    rollup-plugin-lit-css: ^2.x
+    ts-node: ^10.5.0
+    typescript: ^4.5.5
   languageName: unknown
   linkType: soft
 
@@ -997,15 +1027,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/ajv-compiler@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@fastify/ajv-compiler@npm:1.1.0"
-  dependencies:
-    ajv: ^6.12.6
-  checksum: b8a2522ead00a01ab7ff2921f00aa8e4aeb943949191ce2a617c88e4679db1358a70e4099791828a397a50e5d6f6bd75184ad0ac75a12dffeb9df4c089986a32
-  languageName: node
-  linkType: hard
-
 "@gar/promisify@npm:^1.0.1":
   version: 1.1.2
   resolution: "@gar/promisify@npm:1.1.2"
@@ -1075,60 +1096,6 @@ __metadata:
     graphql-code-generator: bin.js
     graphql-codegen: bin.js
   checksum: 3671559631c373449580b158455d86160f021fbf28bd3b69c2773862527da31730e6aafddbf11aac37cfbed886e7b570dcc753d5dc83c64d5f14fcc974a5cba2
-  languageName: node
-  linkType: hard
-
-"@graphql-codegen/cli@npm:^2.3.0":
-  version: 2.6.2
-  resolution: "@graphql-codegen/cli@npm:2.6.2"
-  dependencies:
-    "@graphql-codegen/core": 2.5.1
-    "@graphql-codegen/plugin-helpers": ^2.4.1
-    "@graphql-tools/apollo-engine-loader": ^7.0.5
-    "@graphql-tools/code-file-loader": ^7.0.6
-    "@graphql-tools/git-loader": ^7.0.5
-    "@graphql-tools/github-loader": ^7.0.5
-    "@graphql-tools/graphql-file-loader": ^7.0.5
-    "@graphql-tools/json-file-loader": ^7.1.2
-    "@graphql-tools/load": ^7.3.0
-    "@graphql-tools/prisma-loader": ^7.0.6
-    "@graphql-tools/url-loader": ^7.0.11
-    "@graphql-tools/utils": ^8.1.1
-    ansi-escapes: ^4.3.1
-    chalk: ^4.1.0
-    change-case-all: 1.0.14
-    chokidar: ^3.5.2
-    common-tags: ^1.8.0
-    cosmiconfig: ^7.0.0
-    debounce: ^1.2.0
-    dependency-graph: ^0.11.0
-    detect-indent: ^6.0.0
-    glob: ^7.1.6
-    globby: ^11.0.4
-    graphql-config: ^4.1.0
-    inquirer: ^8.0.0
-    is-glob: ^4.0.1
-    json-to-pretty-yaml: ^1.2.2
-    latest-version: 5.1.0
-    listr: ^0.14.3
-    listr-update-renderer: ^0.5.0
-    log-symbols: ^4.0.0
-    minimatch: ^4.0.0
-    mkdirp: ^1.0.4
-    string-env-interpolation: ^1.0.1
-    ts-log: ^2.2.3
-    tslib: ~2.3.0
-    valid-url: ^1.0.9
-    wrap-ansi: ^7.0.0
-    yaml: ^1.10.0
-    yargs: ^17.0.0
-  peerDependencies:
-    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  bin:
-    gql-gen: bin.js
-    graphql-code-generator: bin.js
-    graphql-codegen: bin.js
-  checksum: 5d8f81fab26984588fe4a7cfde12c45d86c101086acb3e2c3e6b23e194be7af6c2a76825c6da996e8841ac8c0a52f23d4658c6a795f345e1d577d75ad8025c2c
   languageName: node
   linkType: hard
 
@@ -1365,21 +1332,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-codegen/typescript@npm:^2.4.1, @graphql-codegen/typescript@npm:^2.4.5":
-  version: 2.4.5
-  resolution: "@graphql-codegen/typescript@npm:2.4.5"
-  dependencies:
-    "@graphql-codegen/plugin-helpers": ^2.4.0
-    "@graphql-codegen/schema-ast": ^2.4.1
-    "@graphql-codegen/visitor-plugin-common": 2.7.1
-    auto-bind: ~4.0.0
-    tslib: ~2.3.0
-  peerDependencies:
-    graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 7e206242c8eaaac725993b6c8393a01e38c685640f0c32a7b81b7961efef26ca08192fc8137d0fdb0ff9562149d2d6290d05dce4d56f4f37bdf107573853c5dc
-  languageName: node
-  linkType: hard
-
 "@graphql-codegen/typescript@npm:^2.4.3":
   version: 2.4.3
   resolution: "@graphql-codegen/typescript@npm:2.4.3"
@@ -1392,6 +1344,21 @@ __metadata:
   peerDependencies:
     graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
   checksum: 4496d71402c798201f914c36462919e9e3022bfea5ec759133c78edc4b656bd8f9ad982bc1f6c93e5c911b49668d3bf87958561b4da133ec110071b59ddcd0ce
+  languageName: node
+  linkType: hard
+
+"@graphql-codegen/typescript@npm:^2.4.5":
+  version: 2.4.5
+  resolution: "@graphql-codegen/typescript@npm:2.4.5"
+  dependencies:
+    "@graphql-codegen/plugin-helpers": ^2.4.0
+    "@graphql-codegen/schema-ast": ^2.4.1
+    "@graphql-codegen/visitor-plugin-common": 2.7.1
+    auto-bind: ~4.0.0
+    tslib: ~2.3.0
+  peerDependencies:
+    graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 7e206242c8eaaac725993b6c8393a01e38c685640f0c32a7b81b7961efef26ca08192fc8137d0fdb0ff9562149d2d6290d05dce4d56f4f37bdf107573853c5dc
   languageName: node
   linkType: hard
 
@@ -2494,7 +2461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/accepts@npm:*":
+"@types/accepts@npm:*, @types/accepts@npm:^1.3.5":
   version: 1.3.5
   resolution: "@types/accepts@npm:1.3.5"
   dependencies:
@@ -2503,7 +2470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/body-parser@npm:*":
+"@types/body-parser@npm:*, @types/body-parser@npm:1.19.2":
   version: 1.19.2
   resolution: "@types/body-parser@npm:1.19.2"
   dependencies:
@@ -2558,6 +2525,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cors@npm:2.8.12":
+  version: 2.8.12
+  resolution: "@types/cors@npm:2.8.12"
+  checksum: 8c45f112c7d1d2d831b4b266f2e6ed33a1887a35dcbfe2a18b28370751fababb7cd045e745ef84a523c33a25932678097bf79afaa367c6cb3fa0daa7a6438257
+  languageName: node
+  linkType: hard
+
 "@types/estree@npm:*":
   version: 0.0.51
   resolution: "@types/estree@npm:0.0.51"
@@ -2572,7 +2546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:^4.17.18":
+"@types/express-serve-static-core@npm:4.17.28, @types/express-serve-static-core@npm:^4.17.18":
   version: 4.17.28
   resolution: "@types/express-serve-static-core@npm:4.17.28"
   dependencies:
@@ -2583,7 +2557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:*":
+"@types/express@npm:*, @types/express@npm:4.17.13":
   version: 4.17.13
   resolution: "@types/express@npm:4.17.13"
   dependencies:
@@ -3261,14 +3235,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abstract-logging@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "abstract-logging@npm:2.0.1"
-  checksum: 6967d15e5abbafd17f56eaf30ba8278c99333586fa4f7935fd80e93cfdc006c37fcc819c5d63ee373a12e6cb2d0417f7c3c6b9e42b957a25af9937d26749415e
-  languageName: node
-  linkType: hard
-
-"accepts@npm:^1.3.5":
+"accepts@npm:^1.3.5, accepts@npm:~1.3.8":
   version: 1.3.8
   resolution: "accepts@npm:1.3.8"
   dependencies:
@@ -3342,7 +3309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.11.0, ajv@npm:^6.12.4, ajv@npm:^6.12.6":
+"ajv@npm:^6.10.0, ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -3354,7 +3321,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.1, ajv@npm:^8.1.0, ajv@npm:^8.10.0":
+"ajv@npm:^8.0.1, ajv@npm:^8.10.0":
   version: 8.10.0
   resolution: "ajv@npm:8.10.0"
   dependencies:
@@ -3471,35 +3438,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-elements-app@workspace:frontend":
-  version: 0.0.0-use.local
-  resolution: "apollo-elements-app@workspace:frontend"
-  dependencies:
-    "@apollo-elements/components": ^2.0.0
-    "@apollo-elements/core": ^1.0.0
-    "@apollo-elements/create": ^3.0.3
-    "@apollo/client": ^3.5.4
-    "@graphql-codegen/cli": ^2.3.0
-    "@graphql-codegen/near-operation-file-preset": ^2.2.2
-    "@graphql-codegen/typed-document-node": ^2.2.1
-    "@graphql-codegen/typescript": ^2.4.1
-    "@graphql-codegen/typescript-operations": ^2.2.1
-    "@open-wc/rollup-plugin-html": ^1.x
-    "@pwrs/eslint-config": ^0.x
-    "@rollup/plugin-commonjs": ^17.x
-    "@rollup/plugin-node-resolve": ^11.x
-    "@web/dev-server": ^0.1.x
-    "@web/dev-server-esbuild": ^0.2.x
-    "@web/dev-server-rollup": ^0.3.x
-    npm-run-all: ^4.x
-    pwa-helpers: ^0.9.1
-    rollup: ^2.x
-    rollup-plugin-esbuild: ^2.x
-    rollup-plugin-lit-css: ^2.x
-    typescript: ^4.x
-  languageName: unknown
-  linkType: soft
-
 "apollo-reporting-protobuf@npm:^3.3.0":
   version: 3.3.0
   resolution: "apollo-reporting-protobuf@npm:3.3.0"
@@ -3566,18 +3504,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-server-fastify@npm:^3.6.3":
+"apollo-server-express@npm:^3.6.3":
   version: 3.6.3
-  resolution: "apollo-server-fastify@npm:3.6.3"
+  resolution: "apollo-server-express@npm:3.6.3"
   dependencies:
+    "@types/accepts": ^1.3.5
+    "@types/body-parser": 1.19.2
+    "@types/cors": 2.8.12
+    "@types/express": 4.17.13
+    "@types/express-serve-static-core": 4.17.28
+    accepts: ^1.3.5
     apollo-server-core: ^3.6.3
     apollo-server-types: ^3.5.1
-    fastify-accepts: ^2.0.1
-    fastify-cors: ^6.0.0
+    body-parser: ^1.19.0
+    cors: ^2.8.5
+    parseurl: ^1.3.3
   peerDependencies:
-    fastify: ^3.17.0
+    express: ^4.17.1
     graphql: ^15.3.0 || ^16.0.0
-  checksum: 244befbf585a0791dbc2e8f9fbfcdb11bbca759eba9bc7b3ad424f87749990ca6ab2885e7e0ff67ed0593c2d615ef2e887e83aef95a89c7727614d992d48122a
+  checksum: 23a13043d8284d80514882db9428f523e5bd3e63fde1fe626e56d06bd212738ac7d16d2e1875bedc4b139d3a7ef3a28552f9f602346f3239ee3fbf2a3ab9dae0
   languageName: node
   linkType: hard
 
@@ -3609,13 +3554,6 @@ __metadata:
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
   checksum: 5615cadcfb45289eea63f8afd064ab656006361020e1735112e346593856f87435e02d8dcc7ff0d11928bc7d425f27bc7c2a84f6c0b35ab0ff659c814c138a24
-  languageName: node
-  linkType: hard
-
-"archy@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "archy@npm:1.0.0"
-  checksum: 504ae7af655130bab9f471343cfdb054feaec7d8e300e13348bc9fe9e660f83d422e473069584f73233c701ae37d1c8452ff2522f2a20c38849e0f406f1732ac
   languageName: node
   linkType: hard
 
@@ -3695,6 +3633,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-flatten@npm:1.1.1":
+  version: 1.1.1
+  resolution: "array-flatten@npm:1.1.1"
+  checksum: a9925bf3512d9dce202112965de90c222cd59a4fbfce68a0951d25d965cf44642931f40aac72309c41f12df19afa010ecadceb07cfff9ccc1621e99d89ab5f3b
+  languageName: node
+  linkType: hard
+
 "array-union@npm:^2.1.0":
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
@@ -3770,18 +3715,6 @@ __metadata:
   version: 4.0.0
   resolution: "auto-bind@npm:4.0.0"
   checksum: 00cad71cce5742faccb7dd65c1b55ebc4f45add4b0c9a1547b10b05bab22813230133b0c892c67ba3eb969a4524710c5e43cc45c72898ec84e56f3a596e7a04f
-  languageName: node
-  linkType: hard
-
-"avvio@npm:^7.1.2":
-  version: 7.2.2
-  resolution: "avvio@npm:7.2.2"
-  dependencies:
-    archy: ^1.0.0
-    debug: ^4.0.0
-    fastq: ^1.6.1
-    queue-microtask: ^1.1.2
-  checksum: ece793dd148dbb50e24f40dacf4852b804405fc1cd34ce794659ffc020c6de41695d87999edc0bb2573c802eaa7766493859dbc432d5dc0079381f318c2705a1
   languageName: node
   linkType: hard
 
@@ -3867,16 +3800,15 @@ __metadata:
     "@typescript-eslint/parser": ^5.11.0
     ajv: ^8.10.0
     apollo-server-core: ^3.6.3
-    apollo-server-fastify: ^3.6.3
+    apollo-server-express: ^3.6.3
     delay: ^5.0.0
     dotenv: ^16.0.0
     env-var: ^7.1.1
     eslint: ^8.8.0
-    fastify: ^3.27.1
-    fastify-plugin: ^3.0.1
-    fastify-websocket: ^4.0.0
+    express: ^4.17.3
     graphql: ^16.3.0
-    graphql-subscriptions: 2.0.0
+    graphql-subscriptions: ^2.0.0
+    graphql-ws: ^5.6.0
     humanize-duration: ^3.27.1
     husky: ~4.3.6
     make-promises-safe: ^5.1.0
@@ -3886,7 +3818,6 @@ __metadata:
     pino-pretty: ~4.3.0
     prettier: ~2.2.1
     pretty-quick: ~3.1.0
-    subscriptions-transport-ws: ^0.11.0
     ts-node: ^10.5.0
     typescript: ^4.5.5
     ws: ^8.4.2
@@ -3929,6 +3860,24 @@ __metadata:
     inherits: ^2.0.4
     readable-stream: ^3.4.0
   checksum: 9e8521fa7e83aa9427c6f8ccdcba6e8167ef30cc9a22df26effcc5ab682ef91d2cbc23a239f945d099289e4bbcfae7a192e9c28c84c6202e710a0dfec3722662
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:1.19.2, body-parser@npm:^1.19.0":
+  version: 1.19.2
+  resolution: "body-parser@npm:1.19.2"
+  dependencies:
+    bytes: 3.1.2
+    content-type: ~1.0.4
+    debug: 2.6.9
+    depd: ~1.1.2
+    http-errors: 1.8.1
+    iconv-lite: 0.4.24
+    on-finished: ~2.3.0
+    qs: 6.9.7
+    raw-body: 2.4.3
+    type-is: ~1.6.18
+  checksum: 7f777ea65670e2622ca4a785b5dcb2a68451b3bb8d4d0f41091d307d56b640dba588a9ae04d85dda2cdd5e42788266a783528d5417e5643720fd611fd52522e7
   languageName: node
   linkType: hard
 
@@ -4019,6 +3968,13 @@ __metadata:
   version: 3.2.0
   resolution: "builtin-modules@npm:3.2.0"
   checksum: 0265aa1ba78e1a16f4e18668d815cb43fb364e6a6b8aa9189c6f44c7b894a551a43b323c40206959d2d4b2568c1f2805607ad6c88adc306a776ce6904cca6715
+  languageName: node
+  linkType: hard
+
+"bytes@npm:3.1.2":
+  version: 3.1.2
+  resolution: "bytes@npm:3.1.2"
+  checksum: e4bcd3948d289c5127591fbedf10c0b639ccbf00243504e4e127374a15c3bc8eed0d28d4aaab08ff6f1cf2abc0cce6ba3085ed32f4f90e82a5683ce0014e1b6e
   languageName: node
   linkType: hard
 
@@ -4572,7 +4528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:~0.5.2":
+"content-disposition@npm:0.5.4, content-disposition@npm:~0.5.2":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:
@@ -4581,7 +4537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:^1.0.4":
+"content-type@npm:^1.0.4, content-type@npm:~1.0.4":
   version: 1.0.4
   resolution: "content-type@npm:1.0.4"
   checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
@@ -4597,7 +4553,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^0.4.0":
+"cookie-signature@npm:1.0.6":
+  version: 1.0.6
+  resolution: "cookie-signature@npm:1.0.6"
+  checksum: f4e1b0a98a27a0e6e66fd7ea4e4e9d8e038f624058371bf4499cfcd8f3980be9a121486995202ba3fca74fbed93a407d6d54d43a43f96fd28d0bd7a06761591a
+  languageName: node
+  linkType: hard
+
+"cookie@npm:0.4.2":
   version: 0.4.2
   resolution: "cookie@npm:0.4.2"
   checksum: a00833c998bedf8e787b4c342defe5fa419abd96b32f4464f718b91022586b8f1bafbddd499288e75c037642493c83083da426c6a9080d309e3bd90fd11baa9b
@@ -4625,6 +4588,16 @@ __metadata:
   version: 3.21.1
   resolution: "core-js-pure@npm:3.21.1"
   checksum: 00a5dff599b7fb0b30746a638b9d0edbdc0df24ed1580ca56be595fbe3c78c375d37fc4e1bff23627109229702c9ee8ea2587a66b8280eb33b85160aa4e401e9
+  languageName: node
+  linkType: hard
+
+"cors@npm:^2.8.5":
+  version: 2.8.5
+  resolution: "cors@npm:2.8.5"
+  dependencies:
+    object-assign: ^4
+    vary: ^1
+  checksum: ced838404ccd184f61ab4fdc5847035b681c90db7ac17e428f3d81d69e2989d2b680cc254da0e2554f5ed4f8a341820a1ce3d1c16b499f6e2f47a1b9b07b5006
   languageName: node
   linkType: hard
 
@@ -4784,7 +4757,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2":
+"debug@npm:2.6.9":
+  version: 2.6.9
+  resolution: "debug@npm:2.6.9"
+  dependencies:
+    ms: 2.0.0
+  checksum: d2f51589ca66df60bf36e1fa6e4386b318c3f1e06772280eea5b1ae9fd3d05e9c2b7fd8a7d862457d00853c75b00451aa2d7459b924629ee385287a650f58fe6
+  languageName: node
+  linkType: hard
+
+"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2":
   version: 4.3.3
   resolution: "debug@npm:4.3.3"
   dependencies:
@@ -4927,6 +4909,13 @@ __metadata:
   version: 1.1.0
   resolution: "destroy@npm:1.1.0"
   checksum: b7c7357f93a38a12ba5c931d37de40d415e2b19ff8d891fed6de38dc6b8a8e8d5fe8e2f55ad13a0d99db4e54980595a6f36b5d48ec467e5f15a60fc6eb9c5c94
+  languageName: node
+  linkType: hard
+
+"destroy@npm:~1.0.4":
+  version: 1.0.4
+  resolution: "destroy@npm:1.0.4"
+  checksum: da9ab4961dc61677c709da0c25ef01733042614453924d65636a7db37308fef8a24cd1e07172e61173d471ca175371295fbc984b0af5b2b4ff47cd57bd784c03
   languageName: node
   linkType: hard
 
@@ -5121,7 +5110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encodeurl@npm:^1.0.2":
+"encodeurl@npm:^1.0.2, encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
   checksum: e50e3d508cdd9c4565ba72d2012e65038e5d71bdc9198cb125beb6237b5b1ade6c0d343998da9e170fb2eae52c1bed37d4d6d98a46ea423a0cddbed5ac3f780c
@@ -5275,7 +5264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-html@npm:^1.0.3":
+"escape-html@npm:^1.0.3, escape-html@npm:~1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
@@ -5635,7 +5624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:^1.8.1":
+"etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
@@ -5690,6 +5679,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express@npm:^4.17.3":
+  version: 4.17.3
+  resolution: "express@npm:4.17.3"
+  dependencies:
+    accepts: ~1.3.8
+    array-flatten: 1.1.1
+    body-parser: 1.19.2
+    content-disposition: 0.5.4
+    content-type: ~1.0.4
+    cookie: 0.4.2
+    cookie-signature: 1.0.6
+    debug: 2.6.9
+    depd: ~1.1.2
+    encodeurl: ~1.0.2
+    escape-html: ~1.0.3
+    etag: ~1.8.1
+    finalhandler: ~1.1.2
+    fresh: 0.5.2
+    merge-descriptors: 1.0.1
+    methods: ~1.1.2
+    on-finished: ~2.3.0
+    parseurl: ~1.3.3
+    path-to-regexp: 0.1.7
+    proxy-addr: ~2.0.7
+    qs: 6.9.7
+    range-parser: ~1.2.1
+    safe-buffer: 5.2.1
+    send: 0.17.2
+    serve-static: 1.14.2
+    setprototypeof: 1.2.0
+    statuses: ~1.5.0
+    type-is: ~1.6.18
+    utils-merge: 1.0.1
+    vary: ~1.1.2
+  checksum: 967e53b74a37eafdf9789b9938c8df86102928b4985b1ad5e385c709deeab405a364de95ca744bc2cc5d05b5d9cc1efc69ae2ae17688a462038648d5a924bfad
+  languageName: node
+  linkType: hard
+
 "external-editor@npm:^3.0.3":
   version: 3.1.0
   resolution: "external-editor@npm:3.1.0"
@@ -5712,13 +5739,6 @@ __metadata:
   version: 11.0.0
   resolution: "extract-files@npm:11.0.0"
   checksum: 39ebd92772e9a1e30d1e3112fb7db85d353c8243640635668b615ac1d605ceb79fbb13d17829dd308993ef37bb189ad99817f79ab164ae95c9bb3df9f440bd16
-  languageName: node
-  linkType: hard
-
-"fast-decode-uri-component@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "fast-decode-uri-component@npm:1.0.1"
-  checksum: 427a48fe0907e76f0e9a2c228e253b4d8a8ab21d130ee9e4bb8339c5ba4086235cf9576831f7b20955a752eae4b525a177ff9d5825dd8d416e7726939194fbee
   languageName: node
   linkType: hard
 
@@ -5749,18 +5769,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stringify@npm:^2.5.2":
-  version: 2.7.13
-  resolution: "fast-json-stringify@npm:2.7.13"
-  dependencies:
-    ajv: ^6.11.0
-    deepmerge: ^4.2.2
-    rfdc: ^1.2.0
-    string-similarity: ^4.0.1
-  checksum: f78ab25047c790de5b521c369e0b18c595055d48a106add36e9f86fe45be40226f168ff4708a226e187d0b46f1d6b32129842041728944bd9a03ca5efbbe4ccb
-  languageName: node
-  linkType: hard
-
 "fast-levenshtein@npm:^2.0.6":
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
@@ -5775,88 +5783,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-safe-stringify@npm:^2.0.7, fast-safe-stringify@npm:^2.0.8":
+"fast-safe-stringify@npm:^2.0.7":
   version: 2.1.1
   resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: a851cbddc451745662f8f00ddb622d6766f9bd97642dabfd9a405fb0d646d69fc0b9a1243cbf67f5f18a39f40f6fa821737651ff1bceeba06c9992ca2dc5bd3d
   languageName: node
   linkType: hard
 
-"fastify-accepts@npm:^2.0.1":
-  version: 2.1.0
-  resolution: "fastify-accepts@npm:2.1.0"
-  dependencies:
-    accepts: ^1.3.5
-    fastify-plugin: ^3.0.0
-  checksum: 40d582281fa898599e34439ebd85627125bd5c26b1d8b6ab05b423edf296909334ff22c017c2428f4019c67d82e266e79157848afbc58e1a9580ac4b5965afc6
-  languageName: node
-  linkType: hard
-
-"fastify-cors@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "fastify-cors@npm:6.0.2"
-  dependencies:
-    fastify-plugin: ^3.0.0
-    vary: ^1.1.2
-  checksum: f600eb30d2259bf0277c3df72c73f09f6891f3984c62e1c9a7489f0d6b2ffb1749dbe9a79a05ad74b08a660c1a707c9fb7636c20b87d07eae0e6efd9c951fd03
-  languageName: node
-  linkType: hard
-
-"fastify-error@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "fastify-error@npm:0.3.1"
-  checksum: fd6a0f6f87b5e4ab59a4d3d66124bd13830a1cf85cf1987259dfb1175fc6a4bcae68b076ad78f6bb06654f72af133b44813090e9ce5502d2ef56ddcb2b0fa867
-  languageName: node
-  linkType: hard
-
-"fastify-plugin@npm:^3.0.0, fastify-plugin@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "fastify-plugin@npm:3.0.1"
-  checksum: 131ba0a388f777829c3fb0fd5b75cf057688ce6d0ca354fb1ebf829767a8c853b0825762b9185b5200097454df0ede2f3095da2efe1aa1b3736d07f194e6d374
-  languageName: node
-  linkType: hard
-
-"fastify-warning@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "fastify-warning@npm:0.2.0"
-  checksum: c19ebccf54a3122877d2248400772ca98bacbabdf97826211ede29246c640d47431a2eebed1f52f9421139ed5e52e42d3bd4aefc46e27b6f34add3507529fd97
-  languageName: node
-  linkType: hard
-
-"fastify-websocket@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "fastify-websocket@npm:4.0.0"
-  dependencies:
-    fastify-plugin: ^3.0.0
-    ws: ^8.0.0
-  checksum: 286dd0dc1d96f25eef74b228e47ad4d621643ba7cac6449f36c5937eb7ed7785e6535640726701d4751acc8ea3a32b7ff2aa0f0ac77a14014b810e47b210df69
-  languageName: node
-  linkType: hard
-
-"fastify@npm:^3.27.1":
-  version: 3.27.1
-  resolution: "fastify@npm:3.27.1"
-  dependencies:
-    "@fastify/ajv-compiler": ^1.0.0
-    abstract-logging: ^2.0.0
-    avvio: ^7.1.2
-    fast-json-stringify: ^2.5.2
-    fastify-error: ^0.3.0
-    find-my-way: ^4.5.0
-    flatstr: ^1.0.12
-    light-my-request: ^4.2.0
-    pino: ^6.13.0
-    process-warning: ^1.0.0
-    proxy-addr: ^2.0.7
-    rfdc: ^1.1.4
-    secure-json-parse: ^2.0.0
-    semver: ^7.3.2
-    tiny-lru: ^7.0.0
-  checksum: a5ff30eac0ab882afe9cea9956b9b93d74c5e345eb6f6218a51d34df3b18dedc17551586aecb16524676d68238110dec7f14005a5c70b9f185a09a1a3ad34837
-  languageName: node
-  linkType: hard
-
-"fastq@npm:^1.6.0, fastq@npm:^1.6.1":
+"fastq@npm:^1.6.0":
   version: 1.13.0
   resolution: "fastq@npm:1.13.0"
   dependencies:
@@ -5942,15 +5876,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-my-way@npm:^4.5.0":
-  version: 4.5.1
-  resolution: "find-my-way@npm:4.5.1"
+"finalhandler@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "finalhandler@npm:1.1.2"
   dependencies:
-    fast-decode-uri-component: ^1.0.1
-    fast-deep-equal: ^3.1.3
-    safe-regex2: ^2.0.0
-    semver-store: ^0.3.0
-  checksum: 85b8c07d34a36f0203438e0c0f0cdbfaf5e1c521ed2e56f9250bed846ceb0eea074127fad7f70137d61bed56387047f212969cc0ba5d818ed5e37b3e3606c43f
+    debug: 2.6.9
+    encodeurl: ~1.0.2
+    escape-html: ~1.0.3
+    on-finished: ~2.3.0
+    parseurl: ~1.3.3
+    statuses: ~1.5.0
+    unpipe: ~1.0.0
+  checksum: 617880460c5138dd7ccfd555cb5dde4d8f170f4b31b8bd51e4b646bb2946c30f7db716428a1f2882d730d2b72afb47d1f67cc487b874cb15426f95753a88965e
   languageName: node
   linkType: hard
 
@@ -5999,13 +5936,6 @@ __metadata:
     flatted: ^3.1.0
     rimraf: ^3.0.2
   checksum: 4fdd10ecbcbf7d520f9040dd1340eb5dfe951e6f0ecf2252edeec03ee68d989ec8b9a20f4434270e71bcfd57800dc09b3344fca3966b2eb8f613072c7d9a2365
-  languageName: node
-  linkType: hard
-
-"flatstr@npm:^1.0.12":
-  version: 1.0.12
-  resolution: "flatstr@npm:1.0.12"
-  checksum: e1bb562c94b119e958bf37e55738b172b5f8aaae6532b9660ecd877779f8559dbbc89613ba6b29ccc13447e14c59277d41450f785cf75c30df9fce62f459e9a8
   languageName: node
   linkType: hard
 
@@ -6062,12 +5992,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fresh@npm:~0.5.2":
+"fresh@npm:0.5.2, fresh@npm:~0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 13ea8b08f91e669a64e3ba3a20eb79d7ca5379a81f1ff7f4310d54e2320645503cc0c78daedc93dfb6191287295f6479544a649c64d8e41a1c0fb0c221552346
   languageName: node
   linkType: hard
+
+"frontend@workspace:frontend":
+  version: 0.0.0-use.local
+  resolution: "frontend@workspace:frontend"
+  dependencies:
+    "@apollo-elements/components": ^2.0.0
+    "@apollo-elements/core": ^1.0.0
+    "@apollo/client": ^3.5.4
+    graphql-ws: ^5.6.0
+    pwa-helpers: ^0.9.1
+  languageName: unknown
+  linkType: soft
 
 "fs-extra@npm:^8.1.0":
   version: 8.1.0
@@ -6395,7 +6337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-subscriptions@npm:2.0.0":
+"graphql-subscriptions@npm:^2.0.0":
   version: 2.0.0
   resolution: "graphql-subscriptions@npm:2.0.0"
   dependencies:
@@ -6403,17 +6345,6 @@ __metadata:
   peerDependencies:
     graphql: ^15.7.2 || ^16.0.0
   checksum: 4735ef86462967bca2f549c5e5e30ca63fb6ddde19a81d8601f38fb12f8bda2b5f1203b33df8fd8d1154ffa3eadc2820d407e64b8fda73e319559256c508af21
-  languageName: node
-  linkType: hard
-
-"graphql-subscriptions@patch:graphql-subscriptions@npm:2.0.0#.yarn/patches/graphql-subscriptions-npm-2.0.0-53564d1c84::locator=2022-game-app%40workspace%3A.":
-  version: 2.0.0
-  resolution: "graphql-subscriptions@patch:graphql-subscriptions@npm%3A2.0.0#.yarn/patches/graphql-subscriptions-npm-2.0.0-53564d1c84::version=2.0.0&hash=fa51e0&locator=2022-game-app%40workspace%3A."
-  dependencies:
-    iterall: ^1.3.0
-  peerDependencies:
-    graphql: ^15.7.2 || ^16.0.0
-  checksum: fb92d898e64b40badb0dc46ec7ef8c41f4a4c6e28b9dd71b8ff3b214173ffd9a5ffd4f80916bce4b7caef7e21521163cc5381147be08ba21ebdfa9fb6b6d653f
   languageName: node
   linkType: hard
 
@@ -6443,6 +6374,15 @@ __metadata:
   peerDependencies:
     graphql: ">=0.11 <=16"
   checksum: bdb77b3e44be53d2d8d0c395066e62e74efe1123d9b5be7cc69b60d28229974e32abc79c5997095d038d169d4135cb2bcb98f0e666aa8cfeb3bb9857b960d803
+  languageName: node
+  linkType: hard
+
+"graphql-ws@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "graphql-ws@npm:5.6.0"
+  peerDependencies:
+    graphql: ">=0.11 <=16"
+  checksum: 97acb90531bdfb2ce09b5851c36dec3555569ebda0f45c4e0391372bb484198a7b6434fe73bd629e55423abae41ccd77f35fbf2fa449f66408b99808d76a3cca
   languageName: node
   linkType: hard
 
@@ -6603,7 +6543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:^1.6.3, http-errors@npm:^1.7.3, http-errors@npm:~1.8.0":
+"http-errors@npm:1.8.1, http-errors@npm:^1.6.3, http-errors@npm:^1.7.3, http-errors@npm:~1.8.0":
   version: 1.8.1
   resolution: "http-errors@npm:1.8.1"
   dependencies:
@@ -6711,7 +6651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.4.24":
+"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
@@ -7705,18 +7645,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"light-my-request@npm:^4.2.0":
-  version: 4.7.1
-  resolution: "light-my-request@npm:4.7.1"
-  dependencies:
-    ajv: ^8.1.0
-    cookie: ^0.4.0
-    fastify-warning: ^0.2.0
-    set-cookie-parser: ^2.4.1
-  checksum: ab4997052533db51f9729b1d2ba4a7609f40cae62c1582041cf627b95cdfc3e08b3629d3dced7052c49cea78043b799f79a5d2a3a769c3f3ab0372cfd7d5ae84
-  languageName: node
-  linkType: hard
-
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
@@ -8111,6 +8039,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"merge-descriptors@npm:1.0.1":
+  version: 1.0.1
+  resolution: "merge-descriptors@npm:1.0.1"
+  checksum: 5abc259d2ae25bb06d19ce2b94a21632583c74e2a9109ee1ba7fd147aa7362b380d971e0251069f8b3eb7d48c21ac839e21fa177b335e82c76ec172e30c31a26
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -8137,6 +8072,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"methods@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "methods@npm:1.1.2"
+  checksum: 0917ff4041fa8e2f2fda5425a955fe16ca411591fbd123c0d722fcf02b73971ed6f764d85f0a6f547ce49ee0221ce2c19a5fa692157931cecb422984f1dcd13a
+  languageName: node
+  linkType: hard
+
 "micromatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "micromatch@npm:4.0.4"
@@ -8160,6 +8102,15 @@ __metadata:
   dependencies:
     mime-db: 1.51.0
   checksum: 67013de9e9d6799bde6d669d18785b7e18bcd212e710d3e04a4727f92f67a8ad4e74aee24be28b685adb794944814bde649119b58ee3282ffdbee58f9278d9f3
+  languageName: node
+  linkType: hard
+
+"mime@npm:1.6.0":
+  version: 1.6.0
+  resolution: "mime@npm:1.6.0"
+  bin:
+    mime: cli.js
+  checksum: fef25e39263e6d207580bdc629f8872a3f9772c923c7f8c7e793175cee22777bbe8bba95e5d509a40aaa292d8974514ce634ae35769faa45f22d17edda5e8557
   languageName: node
   linkType: hard
 
@@ -8199,15 +8150,6 @@ __metadata:
   dependencies:
     brace-expansion: ^1.1.7
   checksum: a3b84b426eafca947741b864502cee02860c4e7b145de11ad98775cfcf3066fef422583bc0ffce0952ddf4750c1ccf4220b1556430d4ce10139f66247d87d69e
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^4.0.0":
-  version: 4.2.1
-  resolution: "minimatch@npm:4.2.1"
-  dependencies:
-    brace-expansion: ^1.1.7
-  checksum: 2b1514e3d0f29a549912f0db7ae7b82c5cab4a8f2dd0369f1c6451a325b3f12b2cf473c95873b6157bb8df183d6cf6db82ff03614b6adaaf1d7e055beccdfd01
   languageName: node
   linkType: hard
 
@@ -8322,6 +8264,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ms@npm:2.0.0":
+  version: 2.0.0
+  resolution: "ms@npm:2.0.0"
+  checksum: 0e6a22b8b746d2e0b65a430519934fefd41b6db0682e3477c10f60c76e947c4c0ad06f63ffdf1d78d335f83edee8c0aa928aa66a36c7cd95b69b26f468d527f4
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
@@ -8329,7 +8278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.0.0, ms@npm:^2.1.1":
+"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -8607,7 +8556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
+"object-assign@npm:^4, object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
@@ -8647,7 +8596,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:^2.3.0":
+"on-finished@npm:^2.3.0, on-finished@npm:~2.3.0":
   version: 2.3.0
   resolution: "on-finished@npm:2.3.0"
   dependencies:
@@ -8918,7 +8867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parseurl@npm:^1.3.2":
+"parseurl@npm:^1.3.2, parseurl@npm:^1.3.3, parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 407cee8e0a3a4c5cd472559bca8b6a45b82c124e9a4703302326e9ab60fc1081442ada4e02628efef1eb16197ddc7f8822f5a91fd7d7c86b51f530aedb17dfa2
@@ -9003,6 +8952,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:0.1.7":
+  version: 0.1.7
+  resolution: "path-to-regexp@npm:0.1.7"
+  checksum: 69a14ea24db543e8b0f4353305c5eac6907917031340e5a8b37df688e52accd09e3cebfe1660b70d76b6bd89152f52183f28c74813dbf454ba1a01c82a38abce
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-type@npm:3.0.0"
@@ -9080,34 +9036,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pino-std-serializers@npm:^3.1.0":
-  version: 3.2.0
-  resolution: "pino-std-serializers@npm:3.2.0"
-  checksum: 77e29675b116e42ae9fe6d4ef52ef3a082ffc54922b122d85935f93ddcc20277f0b0c873c5c6c5274a67b0409c672aaae3de6bcea10a2d84699718dda55ba95b
-  languageName: node
-  linkType: hard
-
 "pino-std-serializers@npm:^4.0.0":
   version: 4.0.0
   resolution: "pino-std-serializers@npm:4.0.0"
   checksum: 89d487729b58c9d3273a0ee851ead068d6d2e2ccc1af8e1c1d28f1b3442423679bec7ec04d9a2aba36f94f335e82be9f4de19dc4fbc161e71c136aaa15b85ad3
-  languageName: node
-  linkType: hard
-
-"pino@npm:^6.13.0":
-  version: 6.13.4
-  resolution: "pino@npm:6.13.4"
-  dependencies:
-    fast-redact: ^3.0.0
-    fast-safe-stringify: ^2.0.8
-    flatstr: ^1.0.12
-    pino-std-serializers: ^3.1.0
-    process-warning: ^1.0.0
-    quick-format-unescaped: ^4.0.3
-    sonic-boom: ^1.0.2
-  bin:
-    pino: bin.js
-  checksum: 8146f2bcd1657127931be902c6e697b9eb1fe71ba7858efa4076ac4a932b6b98ec047667040235e69f802314f2bcbd3d76e915959780fbc0ba0fa3c1b79c417e
   languageName: node
   linkType: hard
 
@@ -9252,7 +9184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-addr@npm:^2.0.7":
+"proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
   dependencies:
@@ -9302,7 +9234,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"queue-microtask@npm:^1.1.2, queue-microtask@npm:^1.2.2":
+"qs@npm:6.9.7":
+  version: 6.9.7
+  resolution: "qs@npm:6.9.7"
+  checksum: 5bbd263332ccf320a1f36d04a2019a5834dc20bcb736431eaccde2a39dcba03fb26d2fd00174f5d7bc26aaad1cad86124b18440883ac042ea2a0fca6170c1bf1
+  languageName: node
+  linkType: hard
+
+"queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: b676f8c040cdc5b12723ad2f91414d267605b26419d5c821ff03befa817ddd10e238d22b25d604920340fd73efd8ba795465a0377c4adf45a4a41e4234e42dc4
@@ -9313,6 +9252,25 @@ __metadata:
   version: 4.0.4
   resolution: "quick-format-unescaped@npm:4.0.4"
   checksum: 7bc32b99354a1aa46c089d2a82b63489961002bb1d654cee3e6d2d8778197b68c2d854fd23d8422436ee1fdfd0abaddc4d4da120afe700ade68bd357815b26fd
+  languageName: node
+  linkType: hard
+
+"range-parser@npm:~1.2.1":
+  version: 1.2.1
+  resolution: "range-parser@npm:1.2.1"
+  checksum: 0a268d4fea508661cf5743dfe3d5f47ce214fd6b7dec1de0da4d669dd4ef3d2144468ebe4179049eff253d9d27e719c88dae55be64f954e80135a0cada804ec9
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:2.4.3":
+  version: 2.4.3
+  resolution: "raw-body@npm:2.4.3"
+  dependencies:
+    bytes: 3.1.2
+    http-errors: 1.8.1
+    iconv-lite: 0.4.24
+    unpipe: 1.0.0
+  checksum: d2961fa3c71c9c22dc2c3fd60ff377bf36dfed7d7a748f2b25d585934a3e9df565bb9aa5bc2e3a716ea941f4bc2a6ddc795c8b0cf7219fb071029b59b1985394
   languageName: node
   linkType: hard
 
@@ -9603,13 +9561,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ret@npm:~0.2.0":
-  version: 0.2.2
-  resolution: "ret@npm:0.2.2"
-  checksum: 774964bb413a3525e687bca92d81c1cd75555ec33147c32ecca22f3d06409e35df87952cfe3d57afff7650a0f7e42139cf60cb44e94c29dde390243bc1941f16
-  languageName: node
-  linkType: hard
-
 "retry@npm:0.13.1":
   version: 0.13.1
   resolution: "retry@npm:0.13.1"
@@ -9628,13 +9579,6 @@ __metadata:
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
   checksum: c3076ebcc22a6bc252cb0b9c77561795256c22b757f40c0d8110b1300723f15ec0fc8685e8d4ea6d7666f36c79ccc793b1939c748bf36f18f542744a4e379fcc
-  languageName: node
-  linkType: hard
-
-"rfdc@npm:^1.1.4, rfdc@npm:^1.2.0":
-  version: 1.3.0
-  resolution: "rfdc@npm:1.3.0"
-  checksum: fb2ba8512e43519983b4c61bd3fa77c0f410eff6bae68b08614437bc3f35f91362215f7b4a73cbda6f67330b5746ce07db5dd9850ad3edc91271ad6deea0df32
   languageName: node
   linkType: hard
 
@@ -9744,15 +9688,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-regex2@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "safe-regex2@npm:2.0.0"
-  dependencies:
-    ret: ~0.2.0
-  checksum: f5e182fca040dedd50ae052ea0eb035d9903b2db71243d5d8b43299735857288ef2ab52546a368d9c6fd1333b2a0d039297925e78ffc14845354f3f6158af7c2
-  languageName: node
-  linkType: hard
-
 "safe-stable-stringify@npm:^2.1.0":
   version: 2.3.1
   resolution: "safe-stable-stringify@npm:2.3.1"
@@ -9771,13 +9706,6 @@ __metadata:
   version: 1.1.0
   resolution: "scuid@npm:1.1.0"
   checksum: cd094ac3718b0070a222f9a499b280c698fdea10268cc163fa244421099544c1766dd893fdee0e2a8eba5d53ab9d0bcb11067bedff166665030fa6fda25a096b
-  languageName: node
-  linkType: hard
-
-"secure-json-parse@npm:^2.0.0":
-  version: 2.4.0
-  resolution: "secure-json-parse@npm:2.4.0"
-  checksum: efaafcaa08a4646ca829b29168474f57fb289a0ca7a1d77b66b55a0292785bc6eb9143b21cfc50b37dd12a823c25b12aa1771f18314ed5a616a1f8f12a318533
   languageName: node
   linkType: hard
 
@@ -9804,13 +9732,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver-store@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "semver-store@npm:0.3.0"
-  checksum: b38f747123e850191526a912657c653c7e5963d164a8daf99e52aa30bc8c5bdac176dc6dab714e17a1a8489ac138c18ff7161b1961f1882888bce637990442dd
-  languageName: node
-  linkType: hard
-
 "semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5.0, semver@npm:^5.6.0, semver@npm:^5.7.1":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
@@ -9829,7 +9750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:^7.2.1, semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:
@@ -9837,6 +9758,27 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 5eafe6102bea2a7439897c1856362e31cc348ccf96efd455c8b5bc2c61e6f7e7b8250dc26b8828c1d76a56f818a7ee907a36ae9fb37a599d3d24609207001d60
+  languageName: node
+  linkType: hard
+
+"send@npm:0.17.2":
+  version: 0.17.2
+  resolution: "send@npm:0.17.2"
+  dependencies:
+    debug: 2.6.9
+    depd: ~1.1.2
+    destroy: ~1.0.4
+    encodeurl: ~1.0.2
+    escape-html: ~1.0.3
+    etag: ~1.8.1
+    fresh: 0.5.2
+    http-errors: 1.8.1
+    mime: 1.6.0
+    ms: 2.1.3
+    on-finished: ~2.3.0
+    range-parser: ~1.2.1
+    statuses: ~1.5.0
+  checksum: c28f36deb4ccba9b8d6e6a1e472b8e7c40a1f51575bdf8f67303568cc9e71131faa3adc36fdb72611616ccad1584358bbe4c3ebf419e663ecc5de868ad3d3f03
   languageName: node
   linkType: hard
 
@@ -9851,17 +9793,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"serve-static@npm:1.14.2":
+  version: 1.14.2
+  resolution: "serve-static@npm:1.14.2"
+  dependencies:
+    encodeurl: ~1.0.2
+    escape-html: ~1.0.3
+    parseurl: ~1.3.3
+    send: 0.17.2
+  checksum: d97f3183b1dfcd8ce9c0e37e18e87fd31147ed6c8ee0b2c3a089d795e44ee851ca5061db01574f806d54f4e4b70bc694d9ca64578653514e04a28cbc97a1de05
+  languageName: node
+  linkType: hard
+
 "set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
-  languageName: node
-  linkType: hard
-
-"set-cookie-parser@npm:^2.4.1":
-  version: 2.4.8
-  resolution: "set-cookie-parser@npm:2.4.8"
-  checksum: e15b5df9a56ab06d4895286033a6aff7b318ad024310df058b5821b3539cc06f716ef529618cac0dd78df40e37830de715f388c0f97f84062dd9be2326efcd0c
   languageName: node
   linkType: hard
 
@@ -10032,16 +9979,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sonic-boom@npm:^1.0.2":
-  version: 1.4.1
-  resolution: "sonic-boom@npm:1.4.1"
-  dependencies:
-    atomic-sleep: ^1.0.0
-    flatstr: ^1.0.12
-  checksum: 189fa8fe5c2dc05d3513fc1a4926a2f16f132fa6fa0b511745a436010cdcd9c1d3b3cb6a9d7c05bd32a965dc77673a5ac0eb0992e920bdedd16330d95323124f
-  languageName: node
-  linkType: hard
-
 "sonic-boom@npm:^2.2.1":
   version: 2.6.0
   resolution: "sonic-boom@npm:2.6.0"
@@ -10175,7 +10112,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:>= 1.4.0 < 2, statuses@npm:>= 1.5.0 < 2, statuses@npm:^1.5.0":
+"statuses@npm:>= 1.4.0 < 2, statuses@npm:>= 1.5.0 < 2, statuses@npm:^1.5.0, statuses@npm:~1.5.0":
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
@@ -10193,13 +10130,6 @@ __metadata:
   version: 1.0.1
   resolution: "string-env-interpolation@npm:1.0.1"
   checksum: d126329587f635bee65300e4451e7352b9b67e03daeb62f006ca84244cac12a1f6e45176b018653ba0c3ec3b5d980f9ca59d2eeed99cf799501cdaa7f871dc6f
-  languageName: node
-  linkType: hard
-
-"string-similarity@npm:^4.0.1":
-  version: 4.0.4
-  resolution: "string-similarity@npm:4.0.4"
-  checksum: 797b41b24e1eb6b3b0ab896950b58c295a19a82933479c75f7b5279ffb63e0b456a8c8d10329c02f607ca1a50370e961e83d552aa468ff3b0fa15809abc9eff7
   languageName: node
   linkType: hard
 
@@ -10533,13 +10463,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-lru@npm:^7.0.0":
-  version: 7.0.6
-  resolution: "tiny-lru@npm:7.0.6"
-  checksum: 36a786a9111a3a358a698c9404783ad3f5396f6ed891672ffa4cd7dec4617abb8dfed6af7611bbaf8a3942a9475534c8b80f9bd58d7efa9aa594f395c9805f09
-  languageName: node
-  linkType: hard
-
 "title-case@npm:^3.0.3":
   version: 3.0.3
   resolution: "title-case@npm:3.0.3"
@@ -10790,7 +10713,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-is@npm:^1.6.16":
+"type-is@npm:^1.6.16, type-is@npm:~1.6.18":
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
   dependencies:
@@ -10809,7 +10732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.5.5, typescript@npm:^4.x":
+"typescript@npm:^4.5.5":
   version: 4.5.5
   resolution: "typescript@npm:4.5.5"
   bin:
@@ -10819,7 +10742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.x#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>":
   version: 4.5.5
   resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=493e53"
   bin:
@@ -10942,6 +10865,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "unpipe@npm:1.0.0"
+  checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
+  languageName: node
+  linkType: hard
+
 "update-notifier@npm:^5.1.0":
   version: 5.1.0
   resolution: "update-notifier@npm:5.1.0"
@@ -11007,6 +10937,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"utils-merge@npm:1.0.1":
+  version: 1.0.1
+  resolution: "utils-merge@npm:1.0.1"
+  checksum: c81095493225ecfc28add49c106ca4f09cdf56bc66731aa8dabc2edbbccb1e1bfe2de6a115e5c6a380d3ea166d1636410b62ef216bb07b3feb1cfde1d95d5080
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^8.0.0":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
@@ -11061,7 +10998,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vary@npm:^1.1.2":
+"vary@npm:^1, vary@npm:^1.1.2, vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
@@ -11356,7 +11293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.0.0, ws@npm:^8.3.0, ws@npm:^8.4.2":
+"ws@npm:^8.3.0, ws@npm:^8.4.2":
   version: 8.5.0
   resolution: "ws@npm:8.5.0"
   peerDependencies:


### PR DESCRIPTION
[graphql-ws](https://npm.im/graphql-ws) package is better maintained than subscriptions-transport-ws and has an esm version however, it will not work with graphql-playground until
https://github.com/graphql/graphql-playground/pull/1295 lands, so this PR also implements GraphiQL

on the frontend, I added a subscription controller. Observe subscriptions by starting a fresh server instance with `yarn dev` and clicking the `connect` button